### PR TITLE
JSONで文字サイズと横幅を指定可能に

### DIFF
--- a/layout.json
+++ b/layout.json
@@ -3,6 +3,7 @@
   "title": "受注データ（マテリアルUI）",
   "excel": { "sheet": "受注データ" },
   "grid_columns": 4,
+  "font_size": 14,
   "fields": [
     {
       "type": "line",
@@ -12,14 +13,16 @@
       "col": 0,
       "validator": "int",
       "min": 0,
-      "max": 99999999
+      "max": 99999999,
+      "width": 200
     },
     {
       "type": "button",
       "text": "データ取得",
       "action": "fetch",
       "row": 1,
-      "col": 1
+      "col": 1,
+      "width": 120
     },
 
     {
@@ -30,7 +33,8 @@
       "col": 0,
       "validator": "int",
       "min": 0,
-      "max": 999999
+      "max": 999999,
+      "width": 200
     },
     {
       "type": "line",
@@ -38,7 +42,8 @@
       "key": "得意先名",
       "row": 2,
       "col": 1,
-      "col_span": 2
+      "col_span": 2,
+      "width": 300
     },
 
     {
@@ -47,7 +52,8 @@
       "key": "品名",
       "row": 3,
       "col": 0,
-      "col_span": 3
+      "col_span": 3,
+      "width": 400
     },
 
     {
@@ -59,7 +65,8 @@
       "validator": "float",
       "min": 0,
       "max": 999999999,
-      "decimals": 3
+      "decimals": 3,
+      "width": 200
     },
     {
       "type": "line",
@@ -70,7 +77,8 @@
       "validator": "float",
       "min": 0,
       "max": 999999999,
-      "decimals": 3
+      "decimals": 3,
+      "width": 200
     },
 
     {
@@ -82,7 +90,8 @@
       "validator": "float",
       "min": 0,
       "max": 999999999,
-      "decimals": 3
+      "decimals": 3,
+      "width": 200
     },
     {
       "type": "line",
@@ -93,7 +102,8 @@
       "validator": "float",
       "min": 0,
       "max": 999999999,
-      "decimals": 3
+      "decimals": 3,
+      "width": 200
     },
 
     {
@@ -105,7 +115,8 @@
       "validator": "float",
       "min": 0,
       "max": 999999999,
-      "decimals": 3
+      "decimals": 3,
+      "width": 200
     },
 
     {
@@ -116,7 +127,8 @@
       "col": 0,
       "validator": "int",
       "min": 0,
-      "max": 99
+      "max": 99,
+      "width": 200
     },
     {
       "type": "line",
@@ -126,7 +138,8 @@
       "col": 1,
       "validator": "int",
       "min": 0,
-      "max": 999999999
+      "max": 999999999,
+      "width": 200
     },
 
     {
@@ -136,18 +149,20 @@
       "row": 8,
       "col": 0,
       "col_span": 3,
-      "height": 160
+      "height": 160,
+      "width": 400
     },
 
     { "type": "spacer", "row": 9, "height": 8 },
 
-    { "type": "button", "text": "保存", "action": "save", "row": 10, "col": 2 },
+    { "type": "button", "text": "保存", "action": "save", "row": 10, "col": 2, "width": 120, "font_size": 16 },
     {
       "type": "button",
       "text": "クリア",
       "action": "clear",
       "row": 10,
-      "col": 3
+      "col": 3,
+      "width": 120
     }
   ]
 }

--- a/main.py
+++ b/main.py
@@ -104,6 +104,8 @@ class MainWindow(QMainWindow):
         super().__init__()
 
         self.config = self._load_layout(layout_path)
+        # JSON全体に共通の文字サイズがあれば読み込み、無ければ12を使います。
+        self.default_font_size = int(self.config.get("font_size", 12))
 
         win = self.config.get("window", {})
         self.setWindowTitle(win.get("title", "フォーム"))
@@ -165,7 +167,8 @@ class MainWindow(QMainWindow):
             grid_col_edit = col * 2 + 1
             grid_span = max(1, min(ncols - col, col_span)) * 2 - 1
 
-            font_size = f.get("font_size", 12)
+            # 各部品に設定された文字サイズを取得し、無ければ共通設定を利用します。
+            font_size = int(f.get("font_size", self.default_font_size))
 
             if ftype == "header":
                 lbl = QLabel(f.get("text", ""))
@@ -184,6 +187,7 @@ class MainWindow(QMainWindow):
 
                 if ftype == "text":
                     edit = QPlainTextEdit()
+                    # JSONで指定された高さを設定します。
                     h = int(f.get("height", 120))
                     edit.setFixedHeight(h)
                 else:
@@ -223,6 +227,10 @@ class MainWindow(QMainWindow):
                     }}
                 """)
 
+                # JSONで指定された横幅を取得し、0より大きければ固定幅を設定します。
+                w = int(f.get("width", 0))
+                if w > 0:
+                    edit.setFixedWidth(w)
                 self.grid.addWidget(edit, row, grid_col_edit, 1, grid_span)
                 self.widgets[key] = edit
                 continue
@@ -245,6 +253,10 @@ class MainWindow(QMainWindow):
                     QPushButton:hover {{ background:#2F6BFF; }}
                     QPushButton:pressed {{ background:#2554CC; }}
                 """)
+                # JSONで指定された横幅を取得し、0より大きければ固定幅を設定します。
+                w = int(f.get("width", 0))
+                if w > 0:
+                    btn.setFixedWidth(w)
                 self.grid.addWidget(btn, row, grid_col_edit,
                                     1, max(1, grid_span))
                 if action == "fetch":


### PR DESCRIPTION
## 概要
- layout.jsonで共通の`font_size`と各部品の`width`を設定できるように
- ボタンごとに文字サイズを上書き可能に

## テスト
- `python -m json.tool layout.json`
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf94f06b48832f879f1e3a6fa19f33