### PR TITLE
進捗ダイアログ表示の改善

### DIFF
--- a/main.py
+++ b/main.py
@@ -228,6 +228,8 @@ class MainWindow(QMainWindow):
             progress_dialog.setMinimumDuration(0)
             progress_dialog.setValue(0)
             progress_dialog.show()
+            # ここでイベントを処理してダイアログをすぐに表示させます。
+            QApplication.processEvents()
 
             # コールバック関数を定義し、シート読込ごとに進捗を更新します。
             def update_progress(current: int, total: int) -> None:


### PR DESCRIPTION
## 概要
- データ取得中の進捗ダイアログを表示後にイベント処理を追加し、読み込み開始直後から表示されるようにしました。

## テスト
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68bfdadc4ea8832fa74cf4717476d436