### PR TITLE
プルダウンの文字色を黒に設定

### DIFF
--- a/main.py
+++ b/main.py
@@ -938,14 +938,19 @@ def main():
 
     app = QApplication(sys.argv)
     apply_stylesheet(app, theme="light_blue.xml")
-    # 無効状態の入力欄やボタンを灰色で表示するためのスタイルを追加します。
-    # 利用できないことが見た目で分かるようにしています。
+    # 無効状態の入力欄やボタンを灰色にするスタイルと、
+    # プルダウン(QComboBox)の文字色を黒にするスタイルを追加します。
+    # 文字色を黒に固定することで、背景色に影響されず視認性が保たれます。
     app.setStyleSheet(app.styleSheet() + """
         QLineEdit:disabled,
         QPlainTextEdit:disabled,
         QPushButton:disabled {
             background-color: #E0E0E0;
             color: #9E9E9E;
+        }
+        QComboBox,
+        QComboBox QAbstractItemView {
+            color: #000000;
         }
     """)
 


### PR DESCRIPTION
## 概要
- QComboBox とドロップダウン表示の文字色を黒に統一
- 既存スタイルと併せて適用し可読性を向上

## テスト
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0deea93e0832faba3ade1a683dc53