### PR TITLE
Excel 読み取り専用で開く問題の修正

### DIFF
--- a/main.py
+++ b/main.py
@@ -380,7 +380,13 @@ def _try_upsert_with_excel(path: str, data: Dict[str, str], sheet_name: str,
         excel.DisplayAlerts = False
 
         try:
-            workbook = excel.Workbooks.Open(path)
+            # 初学者にもわかる説明：Excel が「読み取り専用で開きますか？」と聞いてこないように、
+            #   あらかじめ編集できる設定でブックを開くよう命令します。
+            workbook = excel.Workbooks.Open(
+                path,
+                ReadOnly=False,
+                IgnoreReadOnlyRecommended=True,
+            )
         except Exception:
             return False
 


### PR DESCRIPTION
## Summary
* Excel を自動操作する際に読み取り専用推奨を無視し、上書き保存・新規登録時も編集可能に開くようにしました。

## Testing
* python -m compileall main.py


------
https://chatgpt.com/codex/tasks/task_e_68c9fbd7dc98832fa53060d7c63bbb8f